### PR TITLE
Resurrect build on 2026-04 nightly (1.97.0-nightly, cosmocc 4.0.2)

### DIFF
--- a/aarch64-unknown-linux-cosmo.json
+++ b/aarch64-unknown-linux-cosmo.json
@@ -1,8 +1,8 @@
 {
   "llvm-target": "aarch64-unknown-linux-musl",
-  "target-pointer-width": "64",
+  "target-pointer-width": 64,
   "arch": "aarch64",
-  "data-layout": "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32",
   "os":"linux",
   "env": "musl",
   "panic-strategy":"abort",
@@ -12,12 +12,11 @@
   "exe-suffix": ".com.dbg",
   "emit-debug-gdb-scripts":false,
   "crt-static-default": true,
-  "crt-static-respected": false,
+  "crt-static-respected": true,
   "linker-is-gnu":true,
   "allows-weak-linkage":true,
   "has-rpath": false,
   "has-thread-local": false,
-  "is-builtin": false,
   "trap-unreachable":true,
   "position-independent-executables": false,
   "static-position-independent-executables": false,
@@ -30,16 +29,9 @@
   "max-atomic-width":64,
   "linker-flavor":"gcc",
   "linker": "./gcc-linker-wrapper.bash",
-  "late-link-args": {
-      "gcc": []
-  },
   "pre-link-args": {
       "gcc": [
           "-static"
-      ]
-  },
-  "post-link-args": {
-      "gcc": [
       ]
   },
   "stack-probes": {

--- a/build-fat.sh
+++ b/build-fat.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Build a fat (x86_64 + aarch64) APE from one of the src/bin/*.rs binaries.
+#
+# Requires:
+#   - cosmocc 4.x release tree (set COSMO to its top level)
+#   - nightly rustc with rust-src component
+#
+# Usage:
+#   COSMO=/path/to/cosmocc-4.0.2 ./build-fat.sh [--bin hello] [--release]
+set -euo pipefail
+
+: "${COSMO:?set COSMO to the cosmocc release tree (e.g. .../cosmocc-4.0.2)}"
+
+BIN="hello"
+PROFILE_DIR="debug"
+CARGO_EXTRA=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bin) BIN="$2"; shift 2;;
+    --release) PROFILE_DIR="release"; CARGO_EXTRA+=(--release); shift;;
+    *) echo "unknown arg: $1" >&2; exit 2;;
+  esac
+done
+
+export PATH="$COSMO/bin:$PATH"
+
+ARCH=x86_64 cargo +nightly build "${CARGO_EXTRA[@]}" \
+  --bin "$BIN" --target=./x86_64-unknown-linux-cosmo.json -Z json-target-spec
+
+ARCH=aarch64 cargo +nightly build "${CARGO_EXTRA[@]}" \
+  --bin "$BIN" --target=./aarch64-unknown-linux-cosmo.json -Z json-target-spec
+
+"$COSMO/bin/apelink" \
+  -l "$COSMO/bin/ape-x86_64.elf" \
+  -l "$COSMO/bin/ape-aarch64.elf" \
+  -M "$COSMO/bin/ape-m1.c" \
+  -o "./${BIN}.com" \
+  "./target/x86_64-unknown-linux-cosmo/${PROFILE_DIR}/${BIN}.com.dbg" \
+  "./target/aarch64-unknown-linux-cosmo/${PROFILE_DIR}/${BIN}.com.dbg"
+
+ls -la "./${BIN}.com"
+file "./${BIN}.com"

--- a/x86_64-unknown-linux-cosmo.json
+++ b/x86_64-unknown-linux-cosmo.json
@@ -1,8 +1,8 @@
 {
   "llvm-target": "x86_64-unknown-linux-musl",
-  "target-pointer-width": "64",
+  "target-pointer-width": 64,
   "arch": "x86_64",
-  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
   "cpu": "x86-64",
   "os":"linux",
   "env": "musl",
@@ -13,12 +13,11 @@
   "exe-suffix": ".com.dbg",
   "emit-debug-gdb-scripts":false,
   "crt-static-default": true,
-  "crt-static-respected": false,
+  "crt-static-respected": true,
   "linker-is-gnu":true,
   "allows-weak-linkage":true,
   "has-rpath": false,
   "has-thread-local": false,
-  "is-builtin": false,
   "trap-unreachable":true,
   "position-independent-executables": false,
   "static-position-independent-executables": false,
@@ -31,18 +30,11 @@
   "max-atomic-width":64,
   "linker-flavor":"gcc",
   "linker": "./gcc-linker-wrapper.bash",
-  "late-link-args": {
-      "gcc": []
-  },
   "pre-link-args": {
       "gcc": [
           "-static",
           "-pg",
           "-mnop-mcount"
-      ]
-  },
-  "post-link-args": {
-      "gcc": [
       ]
   },
   "stack-probes": {


### PR DESCRIPTION
Five minimal target-JSON schema-drift fixes to get hello-world compiling and linking into a fat APE on current rustc nightly. No Cargo.toml, libc crate, src/, or linker-wrapper changes needed.

Target spec fixes (same in both x86_64 and aarch64 JSONs):
  1. target-pointer-width: "64" (string) -> 64 (number)
  2. Remove is-builtin: no longer a recognised target-spec field
  3. Remove empty late-link-args/post-link-args arrays: rustc now errors out with "linker flavor args must not be empty"
  4. crt-static-respected: false -> true (required when crt-static-default is true)
  5. data-layout: align with current LLVM musl layout
     - x86_64: add -i128:128-
     - aarch64: add p270/p271/p272 prefixes and -Fn32 suffix

Also requires passing -Z json-target-spec to cargo (path-based custom target specs are now gated).

Add build-fat.sh: reproducible x86_64+aarch64 build + apelink using a cosmocc release tarball (paths under $COSMO/bin instead of the cosmopolitan monorepo build output paths the README assumes).